### PR TITLE
Set api key command

### DIFF
--- a/commands/gpt_edit.py
+++ b/commands/gpt_edit.py
@@ -1,4 +1,3 @@
-from argparse import ArgumentParser
 from tqdm import tqdm
 from arguement_validator import ArgumentValidator
 from code_parser import CodeParser
@@ -40,6 +39,12 @@ def gpt_edit_function (args):
     code_parser = CodeParser(filename=args.filename, function_names=args.target_functions, class_names=args.target_classes, method_names=args.target_methods)
 
     gpt_request = GptRequest(gpt_4=args.gpt_4)
+
+    try:
+        gpt_request.get_api_key()
+    except Exception as e:
+        print(e)
+        return
     
     # tasks for the terminal progress bar
     total_tasks = 4 + args.create_review_file + args.edit_code_in_file

--- a/commands/review_to_file.py
+++ b/commands/review_to_file.py
@@ -1,8 +1,5 @@
-from argparse import ArgumentParser
-from tqdm import tqdm
 from arguement_validator import ArgumentValidator
 from code_parser import CodeParser
-from gpt_request import GptRequest
 
 def review_to_file_parser(subparsers):
     # set the command name to be used in termainal

--- a/commands/set_api_key.py
+++ b/commands/set_api_key.py
@@ -1,0 +1,31 @@
+from os import path, makedirs
+
+def set_api_key_parser(subparsers):
+    # set the command name to be used in termainal
+    parser = subparsers.add_parser('set-api-key')
+
+    # set the arguments
+    parser.add_argument('api_key', type=str, help='The open ai api key for the user. Key can be found here https://platform.openai.com/account/api-keys if you have a valid openai account.')
+
+    return parser
+
+def set_api_key_function(args):
+    """
+    Prompts the user for their OpenAI API key and saves it to a configuration file in the user's home directory.
+    """
+
+    # api key supplied by the user
+    api_key = args.api_key
+    
+    # Define the directory and file path for the configuration file
+    config_dir = path.expanduser('~/.chatgpt_cli/')
+    config_file = path.join(config_dir, 'config.txt')
+    
+    # Create the configuration directory if it doesn't exist
+    makedirs(config_dir, exist_ok=True)
+    
+    # write the API key to the configuration file
+    with open(config_file, 'w') as f:
+        f.write(api_key)
+
+    print('API key saved.')

--- a/gpt_request.py
+++ b/gpt_request.py
@@ -1,7 +1,7 @@
 import asyncio
 import aiohttp
 import json
-from os import environ
+from os import path
 from markdown_it import MarkdownIt
 
 class GptRequest:
@@ -14,8 +14,29 @@ class GptRequest:
         self.gpt_4 = gpt_4
         self.temp = temp
         self.prompts = []
-        self.GPT_API_KEY = environ.get("GPT_API_KEY")
+        self.GPT_API_KEY = ""
         self.edited_functions = []
+
+    def get_api_key(self):
+        """
+        Retrieve the OpenAI API key from a configuration file in the user's home directory.
+    
+        Raises:
+            Exception: If the configuration file is not found.
+        """
+    
+        # Define the directory and file path for the configuration file
+        config_dir = path.expanduser('~/.chatgpt_cli/')
+        config_file = path.join(config_dir, 'config.txt')
+    
+        try:
+            # Attempt to open and read the API key from the configuration file
+            with open(config_file, 'r') as f:
+                # set the api_key to the one found in the file
+                self.GPT_API_KEY = f.read().strip()
+        except FileNotFoundError:
+            # If the file is not found, raise an exception instructing the user to set the API key
+            raise Exception('API key not found. Please set your API key using set-api-key command.')
 
     def create_prompts(self, functions: list, refactor: bool = False, comments: bool = False, docstrings: bool = False, error_handling: bool = False):
         """

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from argparse import ArgumentParser
 from commands.gpt_edit import gpt_edit_parser, gpt_edit_function
 from commands.review_to_file import review_to_file_parser, review_to_file_function
+from commands.set_api_key import set_api_key_parser, set_api_key_function
 
 
 def main():
@@ -12,6 +13,8 @@ def main():
     gpt_edit_parser(subparsers).set_defaults(func=gpt_edit_function)
     # set arguments and function for review-to-file command
     review_to_file_parser(subparsers).set_defaults(func=review_to_file_function)
+    # set arguments and function for config command
+    set_api_key_parser(subparsers).set_defaults(func=set_api_key_function)
     # parse the arguments
     args = parser.parse_args()
 


### PR DESCRIPTION
add the set-api-key command

users now set their api key which is stored in '~/.chatgpt_cli/config.txt using the command

a function on GptRequest get_api_key now checks for the api key raises an exception if not found

replaces the old method were the api key was set as a enviroment variable and retrieved using os.getenv